### PR TITLE
Fixed possible collision in environment variable

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -8,6 +8,7 @@ if [ -z "$NAME" ]; then
 fi
 
 SUBNAME=$(echo $NAME | tr '[A-Z]' '[a-z]')
+SUBPATH="$(echo $NAME | tr '[a-z-]' '[A-Z_]')_PATH"
 ENVNAME="$(echo $NAME | tr '[a-z-]' '[A-Z_]')_ROOT"
 
 echo "Preparing your '$SUBNAME' sub!"
@@ -17,7 +18,7 @@ if [ "$NAME" != "sub" ]; then
   mv share/sub share/$SUBNAME
 
   for file in **/sub*; do
-    sed "s/sub/$SUBNAME/g;s/SUB_ROOT/$ENVNAME/g" "$file" > $(echo $file | sed "s/sub/$SUBNAME/")
+    sed "s/sub/$SUBNAME/g;s/SUB_ROOT/$ENVNAME/g;s/SUB_PATH/$SUBPATH/g" "$file" > $(echo $file | sed "s/sub/$SUBNAME/")
     rm $file
   done
 


### PR DESCRIPTION
Prepared subs are exporting `SUB_PATH`. If multiple instances of sub are used, a naming collision occurs. This change updates the export name to match the custom name.

`./prepare.sh tst`
SUB_PATH > TST_PATH
