### PR TITLE
Fix README to suggest cloning the project that corresponds to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Now, `rush w` should run `libexec/rush-who`, and save you mere milliseconds of t
 
 Clone this repo:
 
-    git clone git://github.com/37signals/sub.git [name of your sub]
+    git clone git://github.com/zillow/sub.git [name of your sub]
     cd [name of your sub]
     ./prepare.sh [name of your sub]
 


### PR DESCRIPTION
The docs still suggested cloning the old fork.
