### PR TITLE
Remove dead line for "export PATH", move _SUB_ROOT"

### DIFF
--- a/libexec/sub
+++ b/libexec/sub
@@ -29,13 +29,13 @@ _sub_source() {
 }
 
 
-#export _SUB_ROOT="$(abs_dirname "$libexec_path")"
-#export PATH="${libexec_path}:$PATH"
-
 export _original_path=$PATH
 source_command=0
 libexec_path="$(abs_dirname "$0")"
 export PATH="$libexec_path:$PATH"
+
+#export _SUB_ROOT="$(abs_dirname "$libexec_path")"
+
 
 command="$1"
 case "$command" in


### PR DESCRIPTION
The commented out line for "export PATH" was duplicated as a live line of code a few lines earlier. There was no apparent reason to keep the extra commented out copy. 

It's not clear why the "export _SUB_ROOT" line was commented out, but it gave the appearance that commenting it in would make it work. However, it doesn't work because $libexec_path is not yet defined. By moving this line slightly further down, it will work if it is commented in.
